### PR TITLE
docs: adds modules' description of used functions

### DIFF
--- a/include/canvas.h
+++ b/include/canvas.h
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/17 18:28:08 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/04/19 14:29:07 by yde-goes         ###   ########.fr       */
+/*   Updated: 2023/04/24 09:22:11 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,25 +17,96 @@
 # include "mlx.h"
 
 # define K_ESCAPE        0xff1b
+# define K_Q             0x0071
 # define DESTROYNOTIFY   17
 # define NOEVENTMASK     0L
-# define K_Q             0x0071
 
+/**
+ * ABOUT THE HEADER CANVAS.H
+ *
+ * This header contains all funtions that works directly or indirectly with
+ * graphic information and MLX's library manipulation.
+ */
+
+/**
+ * @brief The struct of type t_canvas contains the necessary fields for graphic
+ *        initialization and window rendering.
+ *
+ * @param mlx_ptr Contains the pointer to a connection with the Xserver.
+ * @param win_ptr Contains the pointer to a window created with MLX.
+ * @param img_ptr Contains the pointer to a image created with MLX.
+ * @param addr Stores information about how to write data on pixels from an
+ *             instance of a MLX's windows and image.
+ * @param bpp Contains the bits per pixel value from MLX.
+ * @param line_len Contains the line length value from MLX.
+ * @param endian Stores the most significant endianess order from MLX.
+ * @param width Stores the width of the window and the image created with MLX.
+ * @param height Stores the height of the window and the image created with MLX.
+ */
 typedef struct s_canvas
 {
+	void	*mlx_ptr;
+	void	*win_ptr;
 	void	*img_ptr;
-	int		width;
-	int		height;
+	char	*addr;
 	int		bpp;
 	int		line_len;
 	int		endian;
-	char	*addr;
-	void	*mlx_ptr;
-	void	*win_ptr;
+	int		width;
+	int		height;
 }	t_canvas;
 
+/* ************************************************************************** */
+/*                                  CANVAS.C                                  */
+/* ************************************************************************** */
+
+/**
+ * @brief This function attempts to start a connection with Xserver using MLX
+ *        library. After that, it tries to create a new window on screen with
+ *        the established Xserver connection, width, height and window's title
+ *        passed as parameter. Hereafter, an attempt to create a new image on
+ *        screen with the new window, width and height is done. Lastly, the
+ *        function tries to write information on the new image with a given bits
+ *        per pixel, line length and endianess.
+ *
+ * @param canvas A struct of type t_canvas containing the necessary fields for
+ *               graphic initialization and window rendering.
+ * @param width The desired width of the window to be created.
+ * @param height The desired height of the window to be created.
+ * @param title The desired title to describe the window to be created.
+ * @return (t_bool) If the function successfully establishes a Xserver
+ *         connection, init a window, create a new image on screen and write
+ *         information on it, the function returns TRUE. Otherwise, if one of
+ *         the four aforementioned steps fail, the function returns FALSE.
+ */
 t_bool	new_canvas(t_canvas *canvas, int width, int height, char *title);
+
+/**
+ * @brief This function is to be used as the second parameter of the MLX library
+ *        function mlx_key_hook(), which waits for an user event. If the user
+ *        presses ESC or Q's key, the program is cleanly terminated with quit().
+ *
+ * @param keysym Stores the ID of the key pressed by the user. To see all
+ *               possible values of keysym, refer to the header X11/keysymdef.h.
+ * @param canvas A struct of type t_canvas containing the necessary fields for
+ *               graphic initialization and window rendering.
+ * @return (int) If the keysym passed as parameter is equal to ESC or Q's key,
+ *               the program successfully exits. Otherwise, the function cleanly
+ *               exits with status 0, i.e., EXIT_SUCCESS identifier.
+ */
 int		handle_keypress(int keysym, t_canvas *canvas);
+
+/**
+ * @brief quit() frees every data regarding graphic initialization and window
+ *        rendering. It destroys the created image and window as well as the
+ *        pointer to an established Xserver's connection, whose variable must be
+ *        freed thereafter.
+ *
+ * @param canvas A struct of type t_canvas containing the necessary fields for
+ *               graphic initialization and window rendering.
+ * @return (int) After free routine, the function successfully exits with status
+ *               0, i.e., EXIT_SUCCESS identifier.
+ */
 int		quit(t_canvas *canvas);
 
 #endif

--- a/include/canvas.h
+++ b/include/canvas.h
@@ -81,7 +81,7 @@ typedef struct s_canvas
  *         information on it, the function returns TRUE. Otherwise, if one of
  *         the four aforementioned steps fail, the function returns FALSE.
  */
-t_bool	new_canvas(t_canvas *canvas, int width, int height, char *title);
+// t_bool	new_canvas(t_canvas *canvas, int width, int height, char *title);
 
 /**
  * @brief This function is to be used as the second parameter of the MLX library
@@ -112,8 +112,10 @@ int		handle_keypress(int keysym, t_canvas *canvas);
 int		quit(t_canvas *canvas);
 
 void	init_mlx_connection(t_canvas *canvas);
+t_bool	new_canvas(t_canvas *canvas, int width, int height);
 t_bool	put_on_window(t_canvas *canvas, char *title);
 int		show_window(t_canvas *canvas);
+
 t_bool	render_scene(t_canvas *canvas, t_world *world, t_camera *camera);
 int		rgb(t_color color);
 void	write_pixel(const t_canvas *canvas, int x, int y, int color);

--- a/include/canvas.h
+++ b/include/canvas.h
@@ -111,6 +111,9 @@ int		handle_keypress(int keysym, t_canvas *canvas);
  */
 int		quit(t_canvas *canvas);
 
+void	init_mlx_connection(t_canvas *canvas);
+t_bool	put_on_window(t_canvas *canvas, char *title);
+int		show_window(t_canvas *canvas);
 t_bool	render_scene(t_canvas *canvas, t_world *world, t_camera *camera);
 int		rgb(t_color color);
 void	write_pixel(const t_canvas *canvas, int x, int y, int color);

--- a/include/helpers.h
+++ b/include/helpers.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   helpers.h                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/31 14:48:10 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/04/14 10:37:50 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/04/24 09:25:30 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,7 +16,26 @@
 # include <stdio.h>
 # include <stdlib.h>
 
-/* Out of memory guard. Check if ptr is null, if so, terminate the program. */
+/**
+ * ABOUT THE HEADER HELPERS.H
+ *
+ * This header contains auxiliary functions for the program as a whole, i.e.,
+ * functions that aren't subfunctions of a specific task in a given module.
+ */
+
+/* ************************************************************************** */
+/*                                  GUARDS.C                                  */
+/* ************************************************************************** */
+
+/**
+ * @brief oom() means outside memory guard. This function checks if the pointer
+ *        passed as parameter is NULL. If true, a message with the corresponding
+ *        errno number is printed and the program is terminated.
+ *
+ * @param ptr The pointer to be checked after calling malloc().
+ * @return (void *) Returns the pointer if malloc() succeeded. Otherwise, the
+ *         program is ceased.
+ */
 void	*oom(void *ptr);
 
 #endif

--- a/include/matrices.h
+++ b/include/matrices.h
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/17 13:52:06 by yde-goes          #+#    #+#             */
-/*   Updated: 2023/04/12 15:11:13 by yde-goes         ###   ########.fr       */
+/*   Updated: 2023/04/24 09:22:38 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,12 +19,30 @@
 # include "libft.h"
 # include "tuples.h"
 
+/**
+ * @brief The struct t_matrix stores a matrix up to 4x4 and size of 16. A matrix
+ *        is a grid of numbers that can be manipulated as a single unit.
+ *        Matrices and their operations are the foundational basis which will
+ *        helps us to manipulate points, vectors and, ultimately, shapes.
+ */
 typedef struct s_matrix
 {
 	float	matrix[MAX][MAX];
 	size_t	size;
 }	t_matrix;
 
+/**
+ * @brief The struct t_shearing is a helper type to allow shearing operation on
+ *        matrices. Shearing (or skew) is a complex operation where the 
+ *        coordinate is changed in proportion to the other two coordinates. When
+ *        doing it to a matrix, it means that x will change in proportion to y
+ *        and z, y will change in proportion to x and z and, lastly, z will
+ *        change in proportion to x and y. For example, to apply shearing to the
+ *        x axis of a given matrix, we pass to shearing() a struct of type
+ *        t_shearing containing the y and z values. For instance, when done to
+ *        the y axis, we pass p1 and p2 which stands for x and z. Lastly, when
+ *        applying it to the z axis, we pass x and y as p1 and p2, respectively.
+ */
 typedef struct s_shearing
 {
 	float	p1;
@@ -35,35 +53,218 @@ typedef struct s_shearing
 /*                             MX_OPERATIONS.C                                */
 /* ************************************************************************** */
 
+/**
+ * @brief This function multiplies two matrices. "Mx" means matrix. For more
+ *        information about how matrix multiplication works, refer to the book
+ *        TRTC on page 28.
+ *
+ * @param a Receives the first matrix to be multiplied.
+ * @param b Receives the second matrix to be multiplied.
+ * @return (t_matrix) Returns a new matrix which is the product of the two
+ *         matrices passed to the function as parameter.
+ */
 t_matrix	multiply_mx_mx(t_matrix a, t_matrix b);
+
+/**
+ * @brief This function multiplies a matrix by a tuple. "Mx" means matrix and
+ *        "tp" means tuple. For more information about how vector and matrix
+ *        multiplication works, refer to the following link quoted by author
+ *        J. Buck: https://betterexplained.com/articles/linear-algebra-guide/
+ *
+ * @param a Receives the matrix to be multiplied.
+ * @param b Receives the tuple to be multiplied.
+ * @return (t_tuple) Returns a new tuple which is the product of the two
+ *         variables passed to the function as parameter.
+ */
 t_tuple		multiply_tp_mx(t_matrix a, t_tuple b);
+
+/**
+ * @brief This function transposes the matrix passed to the function as
+ *        parameter. In other words, it turns the first row into the first
+ *        column, the second row into the second column, and so forth. Thus,
+ *        it's importante to remember that the transpose of the identity matrix
+ *        always gives the own identity matrix as result.
+ *
+ * @param t Receives the matrix to be transposed.
+ * @return (t_matrix) Returns a new matrix which is the transposition of the
+ *         matrix passed to the function as parameter.
+ */
 t_matrix	transpose(t_matrix t);
+
+/**
+ * @brief This function get the inverse of a given matrix. That is, if you
+ *        multiply some matrix A by another matrix B, producing C, you can
+ *        multiply C by the inverse of B to get A again. To invert the matrix,
+ *        this function employs a method known as cofactor expansion.
+ *        Additionally, there some interesting properties of the inverse: 1)
+ *        if you invert an identity matrix, the result is also an identity
+ *        matrix. 2) when you multiply a matrix by its inverse, you get as
+ *        result the identity matrix. 3) The inverse of the transpose of a
+ *        matrix and the transpose of the inverse only commute if the matrix is
+ *        symmetric or orthogonal. Otherwise, the result of the two operations
+ *        will always be different.
+ *
+ * @param t Receives the matrix to be inverted.
+ * @return (t_matrix) Returns a new matrix which is the inversion of the matrix
+ *         passed to the function as parameter.
+ */
 t_matrix	inverse(t_matrix t);
 
 /* ************************************************************************** */
 /*                           MX_TRANSFORMATIONS.C                             */
 /* ************************************************************************** */
 
+/**
+ * @brief This function translates a given matrix. Translation is a
+ *        transformation that moves a point. Thus, it's important to note that
+ *        the inverse of a translation matrix is another translation matrix that
+ *        moves points in reverse.
+ *
+ * @param x Receives the x-axis value of the translation.
+ * @param y Receives the y-axis value of the translation.
+ * @param z Receives the z-axis value of the translation.
+ * @return (t_matrix) Returns a new translated matrix from the coordinates
+ *         passed to the function as parameter.
+ */
 t_matrix	translation(float x, float y, float z);
+
+/**
+ * @brief This function scales a given matrix by multiplication. When applied
+ *        to an object centered at the origin, this transformation scales all
+ *        points on the object, effectively making it larger (if the scale value
+ *        is greater than 1) or smaller (if the scale value is less than 1).
+ *        Note that reflection is scaling by a negative value.
+ *
+ * @param x Receives the x-axis value to scale.
+ * @param y Receives the y-axis value to scale.
+ * @param z Receives the z-axis value to scale.
+ * @return (t_matrix) Returns a new scaled matrix from the coordinates passed to
+ *         the function as parameter.
+ */
 t_matrix	scaling(float x, float y, float z);
+
+/**
+ * @brief This function applies shearing (or skew) transformation to a given
+ *        matrix. It has the effect of making straight lines slanted. Each
+ *        coordinate is changed in proportion to the other two coordinates. When
+ *        doing it to a matrix, it means that x will change in proportion to y
+ *        and z, y will change in proportion to x and z and, lastly, z will
+ *        change in proportion to x and y.
+ * 
+ * @param x Receives a struct t_shearing storing the y and z values to change x
+ *          in proportion to them. 
+ * @param y Receives a struct t_shearing storing the x and z values to change y
+ *          in proportion to them. 
+ * @param z Receives a struct t_shearing storing the x and y values to change z
+ *          in proportion to them. 
+ * @return (t_matrix) Returns a new matrix after the shearing operation from
+ *         values passed to the function as parameter.
+ */
 t_matrix	shearing(t_shearing x, t_shearing y, t_shearing z);
 
 /* ************************************************************************** */
 /*                             MX_ROTATIONS.C                                 */
 /* ************************************************************************** */
 
+/**
+ * @brief This function rotates a given matrix around the x-axis.
+ *
+ * @param rad Receives the rotation around x axis to be performed in radians.
+ * @return (t_matrix) Returns a new rotated matrix after the rotation passed to
+ *         the function as parameter.
+ */
 t_matrix	rotation_x(float rad);
+
+/**
+ * @brief This function rotates a given matrix around the y-axis.
+ *
+ * @param rad Receives the rotation around y axis to be performed in radians.
+ * @return (t_matrix) Returns a new rotated matrix after the rotation passed to
+ *         the function as parameter.
+ */
 t_matrix	rotation_y(float rad);
+
+/**
+ * @brief This function rotates a given matrix around the z-axis.
+ *
+ * @param rad Receives the rotation around z axis to be performed in radians.
+ * @return (t_matrix) Returns a new rotated matrix after the rotation passed to
+ *         the function as parameter.
+ */
 t_matrix	rotation_z(float rad);
 
 /* ************************************************************************** */
 /*                             MX_ATTRIBUTES.C                                */
 /* ************************************************************************** */
 
+/**
+ * @brief This function gets the determinant of a given matrix. The determinant
+ *        is a number that is derived from the elements of a matrix. The name
+ *        comes from the use of matrices to solve systems of equations, where
+ *        it’s used to determine whether or not the system has a solution. If
+ *        the determinant is zero, then the corresponding system of equations
+ *        has no solution.
+ *
+ * @param t Receives the matrix to calculate its determinant.
+ * @return (float) Returns a float value which is the determinant of the matrix
+ *         passed to the function as parameter.
+ */
 float		get_determinant(t_matrix t);
+
+/**
+ * @brief This functions gets the submatrix of a given matrix. That is, what is
+ *        left when you delete a single row and column from a matrix. The
+ *        submatrix of a 4x4 matrix is 3x3 and the submatrix of a 3x3 matrix is
+ *        2x2.
+ *
+ * @param t Receives the matrix from which the submatrix will be calculated.
+ * @param del_row Receives a size_t value which stands for the row to be
+ *                deleted when calculating the submatrix.
+ * @param del_col Receives a size_t value which stands for the column to be
+ *                deleted when calculating the submatrix.
+ * @return (t_matrix) Returns the submatrix of the matrix passed to the function
+ *         as parameter.
+ */
 t_matrix	get_submatrix(t_matrix t, size_t del_row, size_t del_col);
+
+/**
+ * @brief This function gets the minor of a given matrix. To put it differently,
+ *        the minor of an element at row i and column j is the determinant of
+ *        the submatrix at (i,j).
+ *
+ * @param t Receives the matrix from which the minor will be calculated.
+ * @param row Receives the row value from which the minor will be calculated.
+ * @param col Receives the column value from which the minor will be calculated.
+ * @return (float) Returns the minor of the matrix passed to the function
+ *         as parameter.
+ */
 float		get_minor(t_matrix t, size_t row, size_t col);
+
+/**
+ * @brief This function gets the cofactor of a given matrix. Cofactors are
+ *        minors that have (possibly) had their sign changed. If row + column
+ *        equals to an odd number as result, the minor must be negated.
+ *        Therefore, if the row and column identifies a spot with a +, then the
+ *        minor’s sign doesn’t change. If the row and column identifies a spot
+ *        with a -, then the minor must be negated.
+ *
+ * @param t Receives the matrix from which the cofactor will be calculated.
+ * @param row Receives the row value from which the cofactor will be calculated.
+ * @param col Receives the column value from which the cofactor will be
+ *            calculated.
+ * @return (float) Returns the cofactor of the matrix passed to the function
+ *         as parameter.
+ */
 float		get_cofactor(t_matrix t, size_t row, size_t col);
+
+/**
+ * @brief This fucntion gets a new matrix with the special attribute of being an
+ *        identity matrix or multiplicative identity. That is, if you multiply
+ *        any matrix or tuple by the identity matrix, you get back the matrix or
+ *        tuple you started with.
+ *
+ * @return (t_matrix) Returns a new instance of an identity matrix.
+ */
 t_matrix	get_identity_matrix(void);
 
 /* ************************************************************************** */
@@ -71,8 +272,41 @@ t_matrix	get_identity_matrix(void);
 /* ************************************************************************** */
 
 t_shearing	to_shear(float a, float b);
+
+/**
+ * @brief This function creates a matrix up to 4x4 and, therefore, size of 16
+ *        (4x4). For instance, a matrix of 3x3 will have a size of 9(3x3).
+ *
+ * @param table A bidimensional array of const float containing the matrix.
+ * @param size A size_t value containing how much elements the array has.
+ * @return (t_matrix) Returns successfully a new matrix created with
+ *         ft_memmove() from the array and array's size passed as parameter to
+ *         the function.
+ */
 t_matrix	create_matrix(const float table[MAX][MAX], size_t size);
+
+/**
+ * @brief The function compare_matrix() checks if two matrices are identical or
+ *        not. The matrices passed as parameter to the function are compared
+ *        with ft_memcmp().
+ *
+ * @param a Receives the first matrix to be compared.
+ * @param b Receives the second matrix to be compared.
+ * @return (int) The function returns 0 if the matrices are identical.
+ *         Otherwise, it returns a non-zero integer.
+ */
 int			compare_matrix(t_matrix	a, t_matrix b);
+
+/**
+ * @brief This function checks if a given matrix is invertible or not. Not every
+ *        matrix is invertible. An matrix is invertible if its determinant is a
+ *        non-zero number. If its determinant is 0, then the given matrix is not
+ *        invertible.
+ *
+ * @param t Receives a matrix to be checked.
+ * @return (t_bool) Returns TRUE if the given matrix is invertible. On the
+ *         contrary, it returns FALSE if it's not invertible.
+ */
 t_bool		is_invertible(t_matrix t);
 
 #endif

--- a/include/rays.h
+++ b/include/rays.h
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/06 10:17:15 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/04/11 14:05:12 by yde-goes         ###   ########.fr       */
+/*   Updated: 2023/04/24 09:22:44 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,14 +15,61 @@
 
 # include "matrices.h"
 
+/**
+ * @brief The struct of type t_ray represents a ray, which is the foundation for
+ *        ray casting. Ray casting is the process of creating a ray, or line,
+ *        and finding the intersections of that ray with the objects in a scene.
+ *
+ * @param origin Stores the starting point of a ray.
+ * @param direction Stores the vector which says where a ray points to.
+ */
 typedef struct s_ray
 {
 	t_point		origin;
 	t_vector	direction;
 }	t_ray;
 
+/* ************************************************************************** */
+/*                                   RAYS.C                                   */
+/* ************************************************************************** */
+
+/**
+ * @brief The function new_ray() creates and queries a ray with the given origin
+ *        and direction passed as parameter.
+ *
+ * @param origin Receives a point tuple, which is starting point of the ray.
+ * @param direction Receives a vector tuple, which is the direction where the
+ *                  ray points to.
+ * @return (t_ray) Sucessfully returns a new ray with the given origin and
+ *         direction passed as parameter to the function.
+ */
 t_ray	new_ray(t_point origin, t_vector direction);
+
+/**
+ * @brief The function position() finds the position of a given ray and a given
+ *        time or distance. To find a ray's position, it's necessary to multiply
+ *        the ray direction by time or distance to find the total distance
+ *        traveled and add the result to the ray's origin.
+ *
+ * @param ray Receives a ray as reference.
+ * @param distance Receives a float value which is the time or distance that the
+ *                 ray must travel.
+ * @return (t_point) Returns the ray's coordinates after it traveled for a given
+ *         time or after it gone through a given distance.
+ */
 t_point	position(t_ray ray, float distance);
+
+/**
+ * @brief The function transform() multiplies a given ray by a given matrix,
+ *        which results in an unnormalized ray. In other words, whatever wanted
+ *        transformation to be applied to a world's object is applied instead in
+ *        the ray by the inverse of the operation intended on a world's object.
+ *        For more information, refer to the book TRTC on page 66.
+ *
+ * @param ray Receives a ray to the transformed.
+ * @param matrix Reveives the matrix transformation to be applied in the ray.
+ * @return (t_ray) Successfully returns a new unnormalized and transformed ray.
+ */
 t_ray	transform(t_ray ray, t_matrix matrix);
 
 #endif

--- a/include/shapes.h
+++ b/include/shapes.h
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/28 18:05:41 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/04/17 20:10:41 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/04/24 15:16:27 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -47,7 +47,28 @@ typedef struct s_distance
 /*                                SPHERES.C                                   */
 /* ************************************************************************** */
 
+/**
+ * @brief This function gets sphere's intersection from ray's origin. If the ray
+ *        is inside the sphere, there is one intersection in front of the ray
+ *        and another one behind it. When the ray intersects the sphere at one
+ *        point only, the function returns two intersections with the same point
+ *        each. This will be helpful when dealing with object overlaps in ch. 16
+ *        (Constructive Solid Geometry - CSG).
+ *
+ * @param sphere A struct of type t_sphere containing a sphere.
+ * @param ray A struct of type t_ray containing a ray.
+ * @return (t_intersection *) Returns the collection of t values where the ray
+ *         intersects the sphere.
+ */
 t_intersection	*intersect(t_sphere *sphere, t_ray ray);
+
+/**
+ * @brief The function set_transform() allows a transformation obtained from the
+ *        function transform() to be assigned to a sphere.
+ * 
+ * @param sphere A struct of type t_sphere storing the sphere to be transformed.
+ * @param transform A matrix containing the transformation's values to be set.
+ */
 void			set_transform(t_sphere *sphere, t_matrix transform);
 
 /**
@@ -69,9 +90,36 @@ t_tuple			normal_at(t_sphere sphere, t_tuple world_point);
 /*                             INTERSECTIONS.C                                */
 /* ************************************************************************** */
 
+/**
+ * @brief One a set of t values has been defined with intersect(). This function
+ *        more parameters to know how to draw the handful intersections that
+ *        were found. i.e., what object was intersected at a given point, what
+ *        color is it, what are its material properties, if should there be a
+ *        reflection or not and so on.  
+ *
+ * @param t Receives the t value of the intersection.
+ * @param sphere Receives the object that was intersected.
+ * @return (t_intersection *) Returns a structure which aggregates the two
+ *         arguments passed as parameter.
+ */
 t_intersection	*intersection(float t, t_sphere *sphere);
+
 void			insert_intersection(t_intersection **xs, t_intersection *i);
+
+/**
+ * @brief By hit, we mean the visible intersections from ray's origin. After
+ *        all, it's possible to have intersections that are behind the ray or
+ *        that were hidden behind (or occluded by) other objects. To sum up, the
+ *        function hit() gets the visible intersections the argument passed as
+ *        parameter to the function.
+ * 
+ * @param xs A struct of type t_intersection storing a collection of
+ *           intersection records.
+ * @return (t_intersection *) Returns the hit from a collection of intersection
+ *         records.
+ */
 t_intersection	*hit(t_intersection *xs);
+
 int				intersection_count(t_intersection *xs);
 void			erase_intersections(t_intersection **xs);
 

--- a/include/tuples.h
+++ b/include/tuples.h
@@ -6,7 +6,7 @@
 /*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/03/09 21:09:16 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/04/16 18:14:55 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/04/24 09:23:00 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -284,9 +284,9 @@ t_color	subtract_color(t_color a, t_color b);
 
 /**
  * @brief The function multiply_color() scales the intensities of each RGB color
- *	component of the parameter color by a constant parameter scalar. For example,
- *	multiply (1, 0, 0) by 0.5 or 1.5 result in (0.5, 0, 0) or (1.5, 0, 0). In
- *	other words, the red components were halved or doubled.
+ *	component of the parameter color by a constant parameter scalar. For
+ *	example, multiplying (1, 0, 0) by 0.5 or 1.5 result in (0.5, 0, 0) or
+ *	(1.5, 0, 0). In other words, the red components were halved or doubled.
  *
  * @param color Receives the color to be scaled.
  * @param scalar Receives the scale factor to be applied for each color value.
@@ -297,10 +297,10 @@ t_color	multiply_color(t_color color, float scalar);
 
 /**
  * @brief The function hadamard_product() blends two color together by
- *	multipling corresponding components of each color. This process is known as
+ *	multiplying corresponding components of each color. This process is known as
  *	Hadamard product or Schur product. For example, to view a yellow-green
- *	surface under reddish-purple light would result in a red-like because the
- *	red component would be highest among the RGB values.
+ *	surface under reddish-purple light would result in a red-like color because
+ *	the red component would be highest among the RGB values.
  *
  * @param a Receives the first color to be blended.
  * @param b Receives the second color to be blended.

--- a/include/world.h
+++ b/include/world.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   world.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mdias-ma <mdias-ma@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: yde-goes <yde-goes@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/04/13 14:17:44 by mdias-ma          #+#    #+#             */
-/*   Updated: 2023/04/19 11:39:11 by mdias-ma         ###   ########.fr       */
+/*   Updated: 2023/04/24 09:23:14 by yde-goes         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,38 +35,38 @@ typedef struct s_comps
 }	t_comps;
 
 /**
- * @brief Find all intersections between a ray and all objects in the world.
+ * @brief Finds all intersections between a ray and all objects in the world.
  *
  * @param world The world of objects to check for intersections.
  * @param ray The ray to check for intersections.
  *
- * @return A pointer to the first intersection in the sorted linked list of
- * intersections, or NULL if no intersections are found.
+ * @return (t_intersection) A pointer to the first intersection in the sorted
+ * linked list of intersections or NULL if no intersections are found.
  */
 t_intersection	*intersect_world(t_world *world, t_ray ray);
 
 /**
- * @brief Precomputes information relating to an intersection.
+ * @brief Precomputes information related to an intersection.
  *
  * Given an intersection between a ray and a shape, this function precomputes
  * the point where the intersection occurred in world space, the eye vector
- * pointing back toward the camera, and the normal vector at the point of
+ * pointing back towards the camera, and the normal vector at the point of
  * intersection. This precomputed information is stored in a new data structure
  * and returned.
  *
- * If the hit occurs on the inside of a shape, the normal vector will be flipped
- * to point in the correct direction.
+ * If the hit point occurs inside of a shape, the normal vector will be flipped
+ * to point to the correct direction.
  *
  * @param intersection The intersection between the ray and a shape.
  * @param ray The ray that intersected with the shape.
- * @return A new data structure containing the precomputed information.
+ * @return (t_comps) A new data structure containing the precomputed information.
  */
 t_comps			prepare_computations(t_intersection *intersection, t_ray ray);
 
 /**
  * @brief Computes the color at an intersection in the given world.
  *
- * Given a world and precomputed information about an intersection between a
+ * Given a world and a precomputed information about an intersection between a
  * ray and a shape, this function computes the color of the intersection point.
  * The color is computed by determining the light that hits the intersection and
  * blending that light with the color of the shape at that point. The resulting
@@ -74,7 +74,7 @@ t_comps			prepare_computations(t_intersection *intersection, t_ray ray);
  *
  * @param world The world in which the intersection occurred.
  * @param comps The precomputed information about the intersection.
- * @return The color of the intersection point.
+ * @return (t_color) The color of the intersection point.
  */
 t_color			shade_hit(t_world world, t_comps comps);
 
@@ -83,17 +83,17 @@ t_color			shade_hit(t_world world, t_comps comps);
  *
  * Given a world and a ray, this function computes the color of the intersection
  * point between the ray and the shapes in the world. It first uses
- * intersect_world to find the intersections between the ray and the shapes in
+ * intersect_world() to find the intersections between the ray and the shapes in
  * the world. If there are no intersections, the function returns the color
  * black. Otherwise, it selects the intersection that is closest to the ray's
  * origin and precomputes the necessary values for that intersection using
- * prepare_computations. Finally, the function calls shade_hit to compute the
- * color at the intersection and returns it.
+ * prepare_computations(). Finally, the function calls shade_hit() to compute
+ * the color at the intersection and returns it.
  *
  * @param world The world in which the intersection occurred.
  * @param ray The ray that intersected with the shapes in the world.
- * @return The color of the intersection point, or black if there is no such
- * intersection.
+ * @return (t_color) The color of the intersection point, or black if there is
+ * no such intersection.
  */
 t_color			color_at(t_world world, t_ray ray);
 


### PR DESCRIPTION
This pull request adds tuples', canvas', helpers', matrices' and rays' documentation as well some minor corrections on world's header description.

To do list:

    [X] - 0) tuples
    [X] - 1) matrices
    [X] - 2) rays
    [X] - 3) shapes**

**It's important to say that there are some structures of world.h and shapes.h missing a description as well the functions insert, delete and count intersections. Since these data and functions will be modified. I decided to not write a Doxygen's style docs for them.
